### PR TITLE
PLF-6252: Failed to get Helper link to PLF Guide when opening intranet w...

### DIFF
--- a/component/uxpnavigation/src/main/java/org/exoplatform/platform/navigation/component/help/Helper.java
+++ b/component/uxpnavigation/src/main/java/org/exoplatform/platform/navigation/component/help/Helper.java
@@ -20,7 +20,6 @@ package org.exoplatform.platform.navigation.component.help;
 
 import org.exoplatform.platform.navigation.component.utils.DashboardUtils;
 import org.exoplatform.platform.navigation.component.utils.NavigationUtils;
-import org.exoplatform.portal.application.PortalRequestContext;
 import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.portal.mop.user.UserNode;
 import org.exoplatform.portal.webui.util.Util;
@@ -29,7 +28,6 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.webui.Utils;
-import org.exoplatform.web.controller.QualifiedName;
 
 /**
  * @author <a href="kmenzli@exoplatform.com">Kmenzli</a>
@@ -130,18 +128,7 @@ public class Helper {
         }
     }
     public static boolean isProfileOwner() {
-      PortalRequestContext request = Util.getPortalRequestContext() ;
-      String currentPath = request.getControllerContext().getParameter(QualifiedName.parse("gtn:path"));
-      String []splitCurrentUser = currentPath.split("/");
-      String userNameInFirstPath = currentPath.split("/")[splitCurrentUser.length - 1];
-      String userNameInSecondPath = currentPath.split("/")[splitCurrentUser.length - 2];
-      if (userNameInFirstPath != null && userNameInFirstPath.equals(Utils.getViewerRemoteId())) {
-        return true;
-      }
-      if (userNameInSecondPath != null && userNameInSecondPath.equals(Utils.getViewerRemoteId())) {
-        return true;
-      }
-      return false;
+        return Utils.getViewerRemoteId().equals(NavigationUtils.getCurrentUser());
     }
     public static String getCurrentPortal()
     {

--- a/component/uxpnavigation/src/main/java/org/exoplatform/platform/navigation/component/utils/NavigationUtils.java
+++ b/component/uxpnavigation/src/main/java/org/exoplatform/platform/navigation/component/utils/NavigationUtils.java
@@ -24,6 +24,10 @@ public class NavigationUtils {
     PortalRequestContext request = Util.getPortalRequestContext() ;
     String currentPath = request.getControllerContext().getParameter(QualifiedName.parse("gtn:path"));
     String []splitCurrentUser = currentPath.split("/");
+    if (splitCurrentUser.length <= 1) {
+      // current path doesn't contain user account
+      return null;
+    }
     String currentUserName = currentPath.split("/")[splitCurrentUser.length - 1];
     try {
       if ((currentUserName != null)&& (idm.getOrCreateIdentity(OrganizationIdentityProvider.NAME, currentUserName, false) != null)) return currentUserName;
@@ -32,9 +36,7 @@ public class NavigationUtils {
         return currentUserName;
       }
     } catch (Exception e) {
-      if(LOG.isDebugEnabled()) {
-        LOG.debug("Could not found Identity of user " + currentUserName);
-      }
+      LOG.warn("Cannot find Identity of user " + currentUserName, e);
       return null;
     }
     return null;


### PR DESCRIPTION
...iki.

Problem analysis:
* When the user opens either intranet's wiki or personal wiki, Helper.isProfileOwner is triggered.
  PLF-6154 changes the implementation of Helper.isProfileOwner which is nearly the implementation of NavigationUtils.getCurrentUser.
  This method gets the second item in a string array without checking the array length.
  In case of intranet's wiki, the string array got from the current path has only 1 item (wiki), ArrayIndexOutOfBoundsException throws.
* In previous version of Platform, this ArrayIndexOutOfBoundsException also happens in NavigationUtils.getCurrentUser() but it is only visible when log is set for debug level.

Fix description:
* Rollback Helper.isProfileOwner which calls NavigationUtils.getCurrentUser to avoid code duplication.
* In NavigationUtils.getCurrentUser, return null when there are less than 2 items in the current path.