### PR TITLE
PLF-6265: cometd's INFO log pollutes browser's console

### DIFF
--- a/extension/portlets/platformNavigation/src/main/webapp/javascript/eXo/platform/navigation/Notification/NotificationPopover.js
+++ b/extension/portlets/platformNavigation/src/main/webapp/javascript/eXo/platform/navigation/Notification/NotificationPopover.js
@@ -18,8 +18,8 @@
         var loc = window.location;
         me.Cometd.configure({
             url: loc.protocol + '//' + loc.hostname + (loc.port ? ':' + loc.port : '')  + '/' + contextName + '/cometd',
-            'exoId': eXoUser, 'exoToken': eXoToken,
-            logLevel: 'debug'
+            'exoId': eXoUser, 'exoToken': eXoToken
+            //logLevel: 'debug'
         });
     
         if (me.currentUser !== eXoUser || me.currentUser === '') {


### PR DESCRIPTION
Fix description:
* Remove logLevel setting in NotificationPopover.js.