### PR TITLE
PLF-6285: [Ubuntu 14.04.2] MIME type isn't recognized when uploading …

### DIFF
--- a/extension/webapp/src/main/webapp/WEB-INF/conf/platform/dms/dms-configuration.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/platform/dms/dms-configuration.xml
@@ -77,7 +77,9 @@
       <values-param>
           <name>untrusted-user-agents</name>
           <value>Microsoft Office Core Storage Infrastructure/1.0</value>
-          <value>gvfs/1.20.1</value>
+          <value>gvfs/1.20.1</value><!-- Ubuntu 14.04 LTS -->
+          <value>gvfs/1.20.2</value><!-- Ubuntu 14.10 -->
+          <value>gvfs/1.20.3</value><!-- Ubuntu 14.04.2 LTS -->
           <value>Microsoft Office Excel 2013</value>
           <value>Microsoft Office Word 2013</value>
           <value>Microsoft Office PowerPoint 2013</value>


### PR DESCRIPTION
…file via Nautilus

Problem analysis:
* Due to a bug since gvfs/1.15.1, file uploaded via Nautilus has octet-stream as MIME type.

Fix description:
* Add the version of gvfs used in Ubuntu 14.10 and 14.04.2 LTS to the untrusted agent list.
  The file extension is then used to detect file's MIME type.