### PR TITLE
ECMS-7412 : add 2 properties for document preview max file size and max page

### DIFF
--- a/extension/config/src/main/resources/conf/platform/configuration.properties
+++ b/extension/config/src/main/resources/conf/platform/configuration.properties
@@ -626,6 +626,13 @@ jcr.documents.versions.max=${exo.ecms.documents.versions.max:0}
 jcr.documents.versions.expiration=${exo.ecms.documents.versions.expiration:0}
 
 
+###########################
+#
+# Document Preview
+#
+exo.ecms.documents.pdfviewer.max-file-size=${exo.ecms.documents.pdfviewer.max-file-size:10}
+exo.ecms.documents.pdfviewer.max-pages=${exo.ecms.documents.pdfviewer.max-pages:99}
+
 #-----------------PLF Software registration------------------------
 registration.skip=${exo.registration.skip:false}
 registration.host=${exo.registration.host:https://community.exoplatform.com}

--- a/extension/config/src/main/resources/conf/platform/exo-sample.properties
+++ b/extension/config/src/main/resources/conf/platform/exo-sample.properties
@@ -333,6 +333,14 @@
 #exo.ecms.documents.versions.max=0
 #exo.ecms.documents.versions.expiration=0
 
+###########################
+#
+# Document Preview
+#
+# Max file size of documents for preview, in Mb
+#exo.ecms.documents.pdfviewer.max-file-size=10
+# Max number of pages of documents for preview
+#exo.ecms.documents.pdfviewer.max-pages=99
 
 
 


### PR DESCRIPTION
This PR adds 2 parameters to configure document limits for preview :
* exo.ecms.documents.pdfviewer.max-file-size (default value : 10)
* exo.ecms.documents.pdfviewer.max-pages (default value : 99)

