### PR TITLE
ES-38 : move ES integration code to PLF code base

### DIFF
--- a/component/common/src/main/resources/conf/portal/setup-navigation.xml
+++ b/component/common/src/main/resources/conf/portal/setup-navigation.xml
@@ -105,5 +105,11 @@
                 <page-reference>group::platform/administrators::monitoring</page-reference>
             </node>  
         </node>
+        <node>
+            <uri>searchIndexing</uri>
+            <name>searchIndexing</name>
+            <label>Search Indexing</label>
+            <page-reference>group::/platform/administrators::searchIndexing</page-reference>
+        </node>
     </page-nodes>
 </node-navigation>

--- a/extension/config/src/main/resources/conf/platform/exo-sample.properties
+++ b/extension/config/src/main/resources/conf/platform/exo-sample.properties
@@ -888,6 +888,19 @@
 #exo.oauth.linkedin.apiKey=<Your LinkedIn clientId>
 #exo.oauth.linkedin.apiSecret=<Your LinkedIn client secret>
 
+################################ Elasticsearch ################################
+
+#exo.es.index.server.url=http://127.0.0.1:9200
+#exo.es.index.server.username=root
+#exo.es.index.server.password=xxxxx
+#exo.es.indexing.batch.number=1000
+#exo.es.indexing.replica.number.default=1
+#exo.es.indexing.shard.number.default=5
+#exo.es.indexing.request.size.limit=10485760
+#exo.es.reindex.batch.size=100
+#exo.es.search.server.url=http://127.0.0.1:9200
+#exo.es.search.server.username=root
+#exo.es.search.server.password=xxxxx
 
 ################################### Add-ons ###################################
 

--- a/extension/webapp/pom.xml
+++ b/extension/webapp/pom.xml
@@ -9,6 +9,19 @@
   <artifactId>platform-extension-webapp</artifactId>
   <packaging>war</packaging>
   <name>eXo Platform - Extension Webapp</name>
+  <properties>
+    <!-- Use version required by Juzu Less plugin -->
+    <org.antlr.runtime.version>3.4</org.antlr.runtime.version>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.antlr</groupId>
+        <artifactId>antlr-runtime</artifactId>
+        <version>${org.antlr.runtime.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>commons-lang</groupId>
@@ -21,6 +34,29 @@
     <dependency>
       <groupId>javax.portlet</groupId>
       <artifactId>portlet-api</artifactId>
+    </dependency>
+    <!-- Juzu -->
+    <dependency>
+      <groupId>org.juzu</groupId>
+      <artifactId>juzu-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.juzu</groupId>
+      <artifactId>juzu-plugins-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.juzu</groupId>
+      <artifactId>juzu-plugins-less4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.juzu</groupId>
+      <artifactId>juzu-plugins-webjars</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.juzu</groupId>
+      <artifactId>juzu-plugins-portlet</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>
@@ -170,6 +206,11 @@
     <dependency>
       <groupId>org.exoplatform.commons</groupId>
       <artifactId>commons-component-upgrade</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-search</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/IndexingManagementApplication.java
+++ b/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/IndexingManagementApplication.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013 eXo Platform SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.exoplatform.search.portlet.indexing.management;
+
+import juzu.Path;
+import juzu.Response;
+import juzu.View;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+public class IndexingManagementApplication {
+
+  @Inject
+  @Path("indexingManagement.gtmpl")
+  org.exoplatform.search.portlet.indexing.management.templates.indexingManagement indexingManagement;
+
+  @View
+  public Response.Content index() throws IOException {
+    return indexingManagement.ok();
+  }
+
+}

--- a/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/app/broadcaster.js
+++ b/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/app/broadcaster.js
@@ -1,0 +1,35 @@
+/**
+ * Created by TClement on 12/17/15.
+ */
+/**
+ * Module responsible to broadcast events to the controllers.
+ * @exports appBroadcaster
+ */
+define('appBroadcaster', ['SHARED/jquery', 'operationController', 'statController', 'connectorController'],
+    function($, operationController, statController, connectorController) {
+
+
+        //Controller
+        var myStatController = new statController();
+        var myOperationController = new operationController();
+        var myConnectorController = new connectorController();
+
+        var appBroadcaster = function appBroadcaster() {
+            var self = this;
+
+            self.onReindexConnector = function() {
+                myConnectorController.refreshConnectorList();
+                myStatController.refreshStatNbOperation();
+                myOperationController.refreshOperationList();
+            }
+
+            self.onDeleteOperation = function() {
+                myOperationController.refreshOperationList();
+                myStatController.refreshStatNbOperation();
+            }
+
+        }
+
+        return appBroadcaster;
+    }
+);

--- a/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/app/controller/connectorController.js
+++ b/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/app/controller/connectorController.js
@@ -1,0 +1,140 @@
+/**
+ * Created by TClement on 12/15/15.
+ */
+/**
+ * Module handling the connector list section.
+ * @exports connectorController
+ */
+define('connectorController', ['SHARED/jquery', 'indexingManagementApi', 'appBroadcaster', 'indexingOperationResource', 'operationEnum'],
+    function($, indexingManagementApi, appBroadcaster, indexingOperationResource, operationEnum) {
+
+        //Service
+        var myIndexingManagementApi = new indexingManagementApi();
+        //Event broadcaster
+        var myAppBroadcaster;
+
+
+        var connectorController = function connectorController() {
+            var self = this;
+
+            /**
+             * Initialize the Connector Controller
+             *
+             * @param {broadcaster} appBroadcaster the appBroadcaster responsible to spread the event to other controller
+             * @return void
+             */
+            self.init = function(appBroadcaster) {
+
+                myAppBroadcaster = appBroadcaster;
+
+                //Init the connector list
+                self.refreshConnectorList();
+                initUiListener();
+
+            }
+
+            /**
+             * Refresh the list of Indexing connectors
+             *
+             * @return void
+             */
+            self.refreshConnectorList = function() {
+                updateConnectorTable();
+            }
+
+        }
+
+        /**
+         * Initialize the listener on UI events (such as onClick, onHover, ...)
+         *
+         * @return void
+         */
+        function initUiListener() {
+            addReindexConnectorUiListener();
+        }
+
+        /**
+         * Declare the event listener handling the click on reindex connector button
+         *
+         * @return void
+         */
+        function addReindexConnectorUiListener() {
+
+            //Reindex connector Event
+            $(document).on('click.btn-connector-reindex', '.btn-connector-reindex', function () {
+
+                //Get operation type
+                var jConnector = $(this);
+                var jConnectorType = jConnector.attr('data-connectorType');
+
+                //Trigger the new Indexing Operation
+                reindexConnector(jConnectorType);
+            });
+
+        }
+
+        /**
+         * Update the table of list of connectors with latest value
+         *
+         * @return void
+         */
+        function updateConnectorTable() {
+            myIndexingManagementApi.getConnectors(null, false, fillConnectorTable);
+        }
+
+        /**
+         * Reindex a connector using the Indexing Management Api
+         *
+         * @param {String} connectorType the type of the connector to reindex
+         * @return void
+         */
+        function reindexConnector(connectorType) {
+
+            //Construct the indexingOperation
+            var indexingOperation = new indexingOperationResource();
+            indexingOperation.setEntityType(connectorType);
+            indexingOperation.setOperation(new operationEnum().REINDEXALL);
+
+            myIndexingManagementApi.addOperation(indexingOperation, myAppBroadcaster.onReindexConnector);
+        }
+
+        /**
+         * Manipulate the DOM to fill the Indexing Connector table
+         *
+         * @param {IndexingConnectorArray} json a JSON array of Indexing Connector
+         * @return void
+         */
+        function fillConnectorTable(json) {
+
+            //Loop on connectors to add one line per connector in the table
+            var html = "";
+            for(var i = 0; i < json.resources.length; i++) {
+
+                var checked = '';
+                if (json.resources[i].enable) checked = 'checked';
+
+                html += "<tr>" +
+                "    <th scope='row'>" + json.resources[i].type + "</th>" +
+                "    <td>" + json.resources[i].description + "</td>" +
+                "    <td>" + json.resources[i].index + "</td>" +
+                "    <td>" +
+                "        <div class='connector-switch'>" +
+                "            <input type='checkbox' name='connector-switch' data-connectorType='" + json.resources[i].type + "' " + checked + ">" +
+                "        </div>" +
+                "    </td>" +
+                "    <td>" +
+                "        <button data-connectorType='" + json.resources[i].type + "' type='button' class='btn-connector-reindex btn btn-primary btn-mini'>" +
+                "           Reindex" +
+                "        </button>" +
+                "    </td>" +
+                "</tr>";
+            }
+
+            //Update the table
+            $('#indexingConnectorTable tbody').html(html);
+
+        }
+
+        return connectorController;
+    }
+);

--- a/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/app/controller/operationController.js
+++ b/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/app/controller/operationController.js
@@ -1,0 +1,133 @@
+/**
+ * Created by TClement on 12/15/15.
+ */
+/**
+ * Module handling the operation list section.
+ * @exports operationController
+ */
+define('operationController', ['SHARED/jquery', 'indexingManagementApi', 'appBroadcaster'],
+    function($, indexingManagementApi, appBroadcaster) {
+
+        //Service
+        var myIndexingManagementApi = new indexingManagementApi();
+        //Event broadcaster
+        var myAppBroadcaster;
+
+        var operationController = function operationController() {
+            var self = this;
+
+            /**
+             * Initialize the Operation Controller
+             *
+             * @param {broadcaster} appBroadcaster the appBroadcaster responsible to spread the event to other controller
+             * @return void
+             */
+            self.init = function(appBroadcaster) {
+
+                myAppBroadcaster = appBroadcaster;
+
+                //Init the Operation list
+                self.refreshOperationList();
+                initUiListener();
+
+                //Set refresh interval for operations list to 5 seconds
+                setInterval(function(){
+                    self.refreshOperationList();
+                }, 5000);
+
+            }
+
+            /**
+             * Refresh the list of Indexing operations
+             *
+             * @return void
+             */
+            self.refreshOperationList = function() {
+                updateOperationTable();
+            }
+
+        }
+
+
+        /**
+         * Initialize the listener on UI events (such as onClick, onHover, ...)
+         *
+         * @return void
+         */
+        function initUiListener() {
+            addDeleteOperationUiListener();
+        }
+
+        /**
+         * Add the event listener handling the click on delete operation button
+         *
+         * @return void
+         */
+        function addDeleteOperationUiListener() {
+            //Deleting queue operation Event
+            $(document).on('click.btn-operation-delete', '.btn-operation-delete', function () {
+
+                //Get operation Id
+                var jOperation = $(this);
+                var jOperationId = jOperation.attr('data-operationId');
+
+                //Trigger the deleting operation
+                deleteOperation(jOperationId);
+            });
+        }
+
+        /**
+         * Update the table of list of operations with latest value
+         *
+         * @return void
+         */
+        function updateOperationTable() {
+            myIndexingManagementApi.getOperations(null, 0, 10, false, fillOperationTable);
+        }
+
+        /**
+         * Delete an operation using the Indexing Management Api
+         *
+         * @param {String} indexingOperationId the id of the operation to delete
+         * @return void
+         */
+        function deleteOperation(indexingOperationId) {
+            myIndexingManagementApi.deleteOperation(indexingOperationId, myAppBroadcaster.onDeleteOperation);
+        }
+
+        /**
+         * Manipulate the DOM to fill the Indexing Operation table
+         *
+         * @param {IndexingOperationArray} json a JSON array of Indexing Operation
+         * @return void
+         */
+        function fillOperationTable(json) {
+
+            //Loop on operations to add one line per Operation in the table
+            var html = "";
+            for(var i = 0; i < json.resources.length; i++) {
+
+                html += "<tr>" +
+                "    <th scope='row'>" + json.resources[i].id + "</th>" +
+                "    <td>" + json.resources[i].entityType + "</td>" +
+                "    <td>" + json.resources[i].entityId + "</td>" +
+                "    <td>" + json.resources[i].operation + "</td>" +
+                "    <td>" + json.resources[i].timestamp + "</td>" +
+                "    <td>" +
+                "        <button type='button'" +
+                "                data-operationId=''" +
+                "                class='btn-operation-delete btn btn-primary btn-mini'>" +
+                "            Delete" +
+                "        </button>" +
+                "    </td>" +
+                "</tr>";
+            }
+
+            //Update the table
+            $('#indexingOperationTable tbody').html(html);
+
+        }
+
+        return operationController;
+    }
+);

--- a/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/app/controller/statController.js
+++ b/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/app/controller/statController.js
@@ -1,0 +1,131 @@
+/**
+ * Created by TClement on 12/15/15.
+ */
+/**
+ * Module handling the stats section (number of connectors/operations/errors).
+ * @exports statController
+ */
+define('statController', ['SHARED/jquery', 'indexingManagementApi', 'appBroadcaster'],
+    function($, indexingManagementApi, appBroadcaster) {
+
+        //Service
+        var myIndexingManagementApi = new indexingManagementApi();
+        //Event broadcaster
+        var myAppBroadcaster;
+
+        var statController = function statController() {
+            var self = this;
+
+            /**
+             * Initialize the Stat Controller
+             *
+             * @param {broadcaster} appBroadcaster the appBroadcaster responsible to spread the event to other controller
+             * @return void
+             */
+            self.init = function(appBroadcaster) {
+
+                myAppBroadcaster = appBroadcaster;
+
+                //Init stats value
+                self.refreshStatNbConnector();
+                self.refreshStatNbOperation();
+                self.refreshStatNbError();
+
+                //Set refresh interval for operations stats to 5 seconds
+                setInterval(function(){
+                    self.refreshStatNbOperation();
+                }, 5000);
+
+            }
+
+            /**
+             * Refresh the Indexing connector number
+             *
+             * @return void
+             */
+            self.refreshStatNbConnector = function() {
+                updateStatNbConnectorValue()
+            }
+
+            /**
+             * Refresh the Indexing operation number
+             *
+             * @return void
+             */
+            self.refreshStatNbOperation = function() {
+                updateStatNbOperationValue()
+            }
+
+            /**
+             * Refresh the Indexing error number
+             *
+             * @return void
+             */
+            self.refreshStatNbError = function() {
+                updateStatNbErrorValue()
+            }
+
+        }
+
+        /**
+         * Update the connector number vlue with latest value
+         *
+         * @return void
+         */
+        function updateStatNbConnectorValue() {
+            myIndexingManagementApi.getConnectors(null, true, updateStatNbConnectorUi);
+        }
+
+        /**
+         * Update the operation number value with latest value
+         *
+         * @return void
+         */
+        function updateStatNbOperationValue() {
+            myIndexingManagementApi.getOperations(null, 0, 0, true, updateStatNbOperationUi);
+        }
+
+        /**
+         * Update the error number value with latest value
+         *
+         * @return void
+         */
+        function updateStatNbErrorValue() {
+            //TODO when Error management will be implemented
+            updateStatNbErrorUi(null);
+        }
+
+
+        /**
+         * Manipulate the DOM to display the connector number value
+         *
+         * @param {json} json a JSON containing the size of connectors
+         * @return void
+         */
+        function updateStatNbConnectorUi(json) {
+            $('#statNbConnector').text(json.size);
+        }
+
+        /**
+         * Manipulate the DOM to display the operation number value
+         *
+         * @param {json} json a JSON containing the size of operations
+         * @return void
+         */
+        function updateStatNbOperationUi(json) {
+            $('#statNbOperation').text(json.size);
+        }
+
+        /**
+         * Manipulate the DOM to display the connector number value
+         *
+         * @param {json} json a JSON containing the size of errors
+         * @return void
+         */
+        function updateStatNbErrorUi(json) {
+            $('#statNbError').text('NA');
+        }
+
+        return statController;
+    }
+);

--- a/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/app/main.js
+++ b/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/app/main.js
@@ -1,0 +1,34 @@
+/**
+ * Module responsible to initialise the application.
+ */
+require(['SHARED/jquery', 'statController', 'connectorController', 'operationController', 'appBroadcaster'],
+    function($, statController, connectorController, operationController, appBroadcaster){
+
+        //Controller
+        var myStatController = new statController();
+        var myConnectorController = new connectorController();
+        var myOperationController = new operationController();
+        //Event broadcaster
+        var myAppBroadcaster = new appBroadcaster();
+
+        /**
+         * Initiliaze all the controller when the doc is ready
+         *
+         */
+        $(document).ready(
+            function($) {
+
+                //Init Stats
+                myStatController.init(myAppBroadcaster);
+
+                //Init Connector list
+                myConnectorController.init(myAppBroadcaster);
+
+                //Init Operation list
+                myOperationController.init(myAppBroadcaster);
+
+            }
+        );
+
+    }
+);

--- a/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/rest/api/VindexingManagementApi.js
+++ b/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/rest/api/VindexingManagementApi.js
@@ -1,0 +1,487 @@
+/*
+ * @javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavascriptClientCodegen", date = "2015-12-09T15:57:02.471+07:00")
+ */
+
+define('indexingManagementApi', ['SHARED/jquery', 'apiClient'],
+    function($, apiClient) {
+
+        var VindexingManagementApi = function VindexingManagementApi() {
+            var self = this;
+
+            var myApiClient = new apiClient();
+
+            /**
+             * Return all Indexing Connectors
+             *
+             * @param {String}  jsonp The name of a JavaScript function to be used as the JSONP callback
+             * @param {Boolean}  returnSize Tell the service if it must return the size of the collection in the store
+             * @param {function} callback the callback function
+             * @return void
+             */
+            self.getConnectors = function(jsonp, returnSize, callback) {
+
+                var postBody = null;
+                var postBinaryBody = null;
+
+                // create path and map variables
+                var basePath = '/rest/private/';
+                // if basePath ends with a /, remove it as path starts with a leading /
+                if (basePath.substring(basePath.length-1, basePath.length)=='/') {
+                    basePath = basePath.substring(0, basePath.length-1);
+                }
+
+                var path = basePath + replaceAll(replaceAll("/v1/indexingManagement/connectors", "\\{format\\}","json"));
+
+                var queryParams = {};
+                var headerParams =  {};
+                var formParams =  {};
+
+
+                if (jsonp != null) queryParams.jsonp = jsonp;
+
+                queryParams.returnSize = returnSize;
+
+
+
+
+                path += createQueryString(queryParams);
+
+                //if (console) {
+                //console.log('path: ' + path);
+                //console.log('queryParams: ' + queryParams);
+                //}
+
+
+
+
+
+                myApiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, null, null, null, callback);
+
+
+
+
+            }
+
+            /**
+             * Return the Indexing Connectors with the specified Connector Type
+             *
+             * @param {String}  connectorType Type of the Indexing Connector to retrieve
+             * @param {String}  jsonp The name of a JavaScript function to be used as the JSONP callback
+             * @param {function} callback the callback function
+             * @return void
+             */
+            self.getConnector = function(connectorType, jsonp, callback) {
+
+                var postBody = null;
+                var postBinaryBody = null;
+
+                // verify the required parameter 'connectorType' is set
+                if (connectorType == null) {
+                    //throw new ApiException(400, "Missing the required parameter 'connectorType' when calling getConnector");
+                    var errorRequiredMsg = "Missing the required parameter 'connectorType' when calling getConnector";
+                    throw errorRequiredMsg;
+                }
+
+                // create path and map variables
+                var basePath = '/rest/private/';
+                // if basePath ends with a /, remove it as path starts with a leading /
+                if (basePath.substring(basePath.length-1, basePath.length)=='/') {
+                    basePath = basePath.substring(0, basePath.length-1);
+                }
+
+                var path = basePath + replaceAll(replaceAll("/v1/indexingManagement/connectors/{connectorType}", "\\{format\\}","json")
+                        , "\\{" + "connectorType" + "\\}", myApiClient.escapeString(connectorType.toString()));
+
+                var queryParams = {};
+                var headerParams =  {};
+                var formParams =  {};
+
+
+                if (jsonp != null) queryParams.jsonp = jsonp;
+
+
+
+
+                path += createQueryString(queryParams);
+
+                //if (console) {
+                //console.log('path: ' + path);
+                //console.log('queryParams: ' + queryParams);
+                //}
+
+
+
+
+
+                myApiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, null, null, null, callback);
+
+
+
+
+            }
+
+            /**
+             * Update an Indexing Connector to enable / disable it
+             *
+             * @param {String}  connectorType Type of the Indexing Connector to update
+             * @param {AnIndexingConnectorResources}  body An Indexing Connector Resource
+             * @param {function} callback the callback function
+             * @return void
+             */
+            self.updateConnector = function(connectorType, body, callback) {
+
+                var postBody = JSON.stringify(body);
+                var postBinaryBody = null;
+
+                // verify the required parameter 'connectorType' is set
+                if (connectorType == null) {
+                    //throw new ApiException(400, "Missing the required parameter 'connectorType' when calling updateConnector");
+                    var errorRequiredMsg = "Missing the required parameter 'connectorType' when calling updateConnector";
+                    throw errorRequiredMsg;
+                }
+
+                // verify the required parameter 'body' is set
+                if (body == null) {
+                    //throw new ApiException(400, "Missing the required parameter 'body' when calling updateConnector");
+                    var errorRequiredMsg = "Missing the required parameter 'body' when calling updateConnector";
+                    throw errorRequiredMsg;
+                }
+
+                // create path and map variables
+                var basePath = '/rest/private/';
+                // if basePath ends with a /, remove it as path starts with a leading /
+                if (basePath.substring(basePath.length-1, basePath.length)=='/') {
+                    basePath = basePath.substring(0, basePath.length-1);
+                }
+
+                var path = basePath + replaceAll(replaceAll("/v1/indexingManagement/connectors/{connectorType}", "\\{format\\}","json")
+                        , "\\{" + "connectorType" + "\\}", myApiClient.escapeString(connectorType.toString()));
+
+                var queryParams = {};
+                var headerParams =  {};
+                var formParams =  {};
+
+
+
+
+
+                path += createQueryString(queryParams);
+
+                //if (console) {
+                //console.log('path: ' + path);
+                //console.log('queryParams: ' + queryParams);
+                //}
+
+
+
+
+
+                myApiClient.invokeAPI(path, "PUT", queryParams, postBody, postBinaryBody, headerParams, formParams, null, null, null, callback);
+
+
+
+
+            }
+
+            /**
+             * Return all Indexing Operations
+             *
+             * @param {String}  jsonp The name of a JavaScript function to be used as the JSONP callback
+             * @param {Integer}  offset The starting point when paging through a list of entities
+             * @param {Integer}  limit The maximum number of results when paging through a list of entities. If not specified or exceed the *query_limit* configuration of Indexing Management rest service, it will use the *query_limit*
+             * @param {Boolean}  returnSize Tell the service if it must return the size of the collection in the store
+             * @param {function} callback the callback function
+             * @return void
+             */
+            self.getOperations = function(jsonp, offset, limit, returnSize, callback) {
+
+                var postBody = null;
+                var postBinaryBody = null;
+
+                // create path and map variables
+                var basePath = '/rest/private/';
+                // if basePath ends with a /, remove it as path starts with a leading /
+                if (basePath.substring(basePath.length-1, basePath.length)=='/') {
+                    basePath = basePath.substring(0, basePath.length-1);
+                }
+
+                var path = basePath + replaceAll(replaceAll("/v1/indexingManagement/operations", "\\{format\\}","json"));
+
+                var queryParams = {};
+                var headerParams =  {};
+                var formParams =  {};
+
+
+                if (jsonp != null) queryParams.jsonp = jsonp;
+
+                queryParams.offset = offset;
+
+                queryParams.limit = limit;
+
+                queryParams.returnSize = returnSize;
+
+
+
+
+                path += createQueryString(queryParams);
+
+                //if (console) {
+                //console.log('path: ' + path);
+                //console.log('queryParams: ' + queryParams);
+                //}
+
+
+
+
+
+                myApiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, null, null, null, callback);
+
+
+
+
+            }
+
+            /**
+             * Add an Indexing Operation to the queue
+             *
+             * @param {AnIndexingOperationResources}  body An Indexing Operation Resource
+             * @param {function} callback the callback function
+             * @return void
+             */
+            self.addOperation = function(body, callback) {
+
+                var postBody = JSON.stringify(body);
+                var postBinaryBody = null;
+
+                // verify the required parameter 'body' is set
+                if (body == null) {
+                    //throw new ApiException(400, "Missing the required parameter 'body' when calling addOperation");
+                    var errorRequiredMsg = "Missing the required parameter 'body' when calling addOperation";
+                    throw errorRequiredMsg;
+                }
+
+                // create path and map variables
+                var basePath = '/rest/private/';
+                // if basePath ends with a /, remove it as path starts with a leading /
+                if (basePath.substring(basePath.length-1, basePath.length)=='/') {
+                    basePath = basePath.substring(0, basePath.length-1);
+                }
+
+                var path = basePath + replaceAll(replaceAll("/v1/indexingManagement/operations", "\\{format\\}","json"));
+
+                var queryParams = {};
+                var headerParams =  {};
+                var formParams =  {};
+
+
+
+
+
+                path += createQueryString(queryParams);
+
+                //if (console) {
+                //console.log('path: ' + path);
+                //console.log('queryParams: ' + queryParams);
+                //}
+
+
+
+
+
+                myApiClient.invokeAPI(path, "POST", queryParams, postBody, postBinaryBody, headerParams, formParams, null, null, null, callback);
+
+
+
+
+            }
+
+            /**
+             * Delete all Indexing Operation
+             *
+             * @param {function} callback the callback function
+             * @return void
+             */
+            self.deleteOperations = function(callback) {
+
+                var postBody = null;
+                var postBinaryBody = null;
+
+                // create path and map variables
+                var basePath = '/rest/private/';
+                // if basePath ends with a /, remove it as path starts with a leading /
+                if (basePath.substring(basePath.length-1, basePath.length)=='/') {
+                    basePath = basePath.substring(0, basePath.length-1);
+                }
+
+                var path = basePath + replaceAll(replaceAll("/v1/indexingManagement/operations", "\\{format\\}","json"));
+
+                var queryParams = {};
+                var headerParams =  {};
+                var formParams =  {};
+
+
+
+
+
+                path += createQueryString(queryParams);
+
+                //if (console) {
+                //console.log('path: ' + path);
+                //console.log('queryParams: ' + queryParams);
+                //}
+
+
+
+
+
+                myApiClient.invokeAPI(path, "DELETE", queryParams, postBody, postBinaryBody, headerParams, formParams, null, null, null, callback);
+
+
+
+
+            }
+
+            /**
+             * Return the Indexing Operation with the specified Opertion Id
+             *
+             * @param {String}  operationId Id of the Indexing Operation to retrieve
+             * @param {String}  jsonp The name of a JavaScript function to be used as the JSONP callback
+             * @param {function} callback the callback function
+             * @return void
+             */
+            self.getOperation = function(operationId, jsonp, callback) {
+
+                var postBody = null;
+                var postBinaryBody = null;
+
+                // verify the required parameter 'operationId' is set
+                if (operationId == null) {
+                    //throw new ApiException(400, "Missing the required parameter 'operationId' when calling getOperation");
+                    var errorRequiredMsg = "Missing the required parameter 'operationId' when calling getOperation";
+                    throw errorRequiredMsg;
+                }
+
+                // create path and map variables
+                var basePath = '/rest/private/';
+                // if basePath ends with a /, remove it as path starts with a leading /
+                if (basePath.substring(basePath.length-1, basePath.length)=='/') {
+                    basePath = basePath.substring(0, basePath.length-1);
+                }
+
+                var path = basePath + replaceAll(replaceAll("/v1/indexingManagement/operations/{operationId}", "\\{format\\}","json")
+                        , "\\{" + "operationId" + "\\}", myApiClient.escapeString(operationId.toString()));
+
+                var queryParams = {};
+                var headerParams =  {};
+                var formParams =  {};
+
+
+                if (jsonp != null) queryParams.jsonp = jsonp;
+
+
+
+
+                path += createQueryString(queryParams);
+
+                //if (console) {
+                //console.log('path: ' + path);
+                //console.log('queryParams: ' + queryParams);
+                //}
+
+
+
+
+
+                myApiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, null, null, null, callback);
+
+
+
+
+            }
+
+            /**
+             * Delete a specified Indexing Operation
+             *
+             * @param {String}  operationId Id of the Indexing Operation to delete
+             * @param {function} callback the callback function
+             * @return void
+             */
+            self.deleteOperation = function(operationId, callback) {
+
+                var postBody = null;
+                var postBinaryBody = null;
+
+                // verify the required parameter 'operationId' is set
+                if (operationId == null) {
+                    //throw new ApiException(400, "Missing the required parameter 'operationId' when calling deleteOperation");
+                    var errorRequiredMsg = "Missing the required parameter 'operationId' when calling deleteOperation";
+                    throw errorRequiredMsg;
+                }
+
+                // create path and map variables
+                var basePath = '/rest/private/';
+                // if basePath ends with a /, remove it as path starts with a leading /
+                if (basePath.substring(basePath.length-1, basePath.length)=='/') {
+                    basePath = basePath.substring(0, basePath.length-1);
+                }
+
+                var path = basePath + replaceAll(replaceAll("/v1/indexingManagement/operations/{operationId}", "\\{format\\}","json")
+                        , "\\{" + "operationId" + "\\}", myApiClient.escapeString(operationId.toString()));
+
+                var queryParams = {};
+                var headerParams =  {};
+                var formParams =  {};
+
+
+
+
+
+                path += createQueryString(queryParams);
+
+                //if (console) {
+                //console.log('path: ' + path);
+                //console.log('queryParams: ' + queryParams);
+                //}
+
+
+
+
+
+                myApiClient.invokeAPI(path, "DELETE", queryParams, postBody, postBinaryBody, headerParams, formParams, null, null, null, callback);
+
+
+
+
+            }
+
+
+
+            function replaceAll (haystack, needle, replace) {
+                var result= haystack;
+                if (needle !=null && replace!=null) {
+                    result= haystack.replace(new RegExp(needle, 'g'), replace);
+                }
+                return result;
+            }
+
+            function createQueryString (queryParams) {
+                var queryString ='';
+                var i = 0;
+                for (var queryParamName in queryParams) {
+                    if (i==0) {
+                        queryString += '?' ;
+                    } else {
+                        queryString += '&' ;
+                    }
+
+                    queryString +=  queryParamName + '=' + encodeURIComponent(queryParams[queryParamName]);
+                    i++;
+                }
+
+                return queryString;
+            }
+        }
+
+        return VindexingManagementApi;
+    }
+);

--- a/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/rest/client/ApiClient.js
+++ b/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/rest/client/ApiClient.js
@@ -1,0 +1,63 @@
+/**
+ * Created by TClement on 12/14/15.
+ */
+
+define('apiClient', ['SHARED/jquery'],
+    function($) {
+
+        var apiClient = function apiClient() {
+            var self = this;
+
+            /**
+             * Invoke API by sending HTTP request with the given options.
+             *
+             * @param path The sub-path of the HTTP URL
+             * @param method The request method, one of "GET", "POST", "PUT", and "DELETE"
+             * @param queryParams The query parameters
+             * @param body The request body object - if it is not binary, otherwise null
+             * @param binaryBody The request body object - if it is binary, otherwise null
+             * @param headerParams The header parameters
+             * @param formParams The form parameters
+             * @param accept The request's Accept header
+             * @param contentType The request's Content-Type header
+             * @param authNames The authentications to apply
+             * @param {function} callback the callback function
+             * @return The response body in type of string
+             */
+            self.invokeAPI = function(path, method, queryParams, body, binaryBody, headerParams, formParams, accept, contentType, authNames, callback) {
+
+                //TODO manage other parameters (header, form) and accept + contentType + basic authentication ?
+
+                var request = {
+                    url: path,
+                    type: method,
+                    cache: false,
+                    dataType: 'json',
+                    contentType: 'application/json; charset=UTF-8',
+                    data: body,
+                    error: function(jqXHR) {
+                        //TODO manage error
+                        console.log("Ajax error " + jqXHR.status);
+                    },
+                    success: function(response) {
+                        callback(response);
+                    }
+                };
+                $.ajax(request);
+
+            }
+
+            /**
+             * Escape the given string to be used as URL query value.
+             */
+            self.escapeString = function(str) {
+                //TODO escape string
+                return str;
+            }
+
+
+        }
+
+        return apiClient;
+    }
+);

--- a/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/rest/model/AnIndexingConnectorResources.js
+++ b/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/rest/model/AnIndexingConnectorResources.js
@@ -1,0 +1,77 @@
+/*
+ * @javax.annotation.Generated(value = "class io.swagger.codegen.languages.JavascriptClientCodegen", date = "2015-12-09T15:57:02.471+07:00")
+ */
+
+/**
+ * Module representing an Indexing Connector Resource.
+ * @exports indexingConnectorResource
+ */
+define('indexingConnectorResource', ['SHARED/jquery'],
+    function($) {
+
+        var AnIndexingConnectorResources = function AnIndexingConnectorResources() {
+            var self = this;
+
+            /**
+             * The Connector Type
+             * datatype: String
+             **/
+            self.type = null;
+
+            /**
+             * Does the Connector is enable or not
+             * datatype: Boolean
+             **/
+            self.enable = null;
+
+
+            self.constructFromObject = function(data) {
+
+                self.type = data.type;
+
+                self.enable = data.enable;
+
+            }
+
+
+            /**
+             * get The Connector Type
+             * @return {String}
+             **/
+            self.getType = function() {
+                return self.type;
+            }
+
+            /**
+             * set The Connector Type
+             * @param {String} type
+             **/
+            self.setType = function (type) {
+                self.type = type;
+            }
+
+            /**
+             * get Does the Connector is enable or not
+             * @return {Boolean}
+             **/
+            self.getEnable = function() {
+                return self.enable;
+            }
+
+            /**
+             * set Does the Connector is enable or not
+             * @param {Boolean} enable
+             **/
+            self.setEnable = function (enable) {
+                self.enable = enable;
+            }
+
+
+            self.toJson = function () {
+                return JSON.stringify(self);
+            }
+        }
+
+        return AnIndexingConnectorResources;
+    }
+);

--- a/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/rest/model/AnIndexingOperationResource.js
+++ b/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/scripts/rest/model/AnIndexingOperationResource.js
@@ -1,0 +1,147 @@
+
+/**
+ * Module representing an Indexing Operation Enum.
+ * @exports operationEnum
+ */
+define('operationEnum', ['SHARED/jquery'],
+    function($) {
+
+        var OperationEnum = function OperationEnum() {
+            var self = this;
+
+
+            /**
+             * @const
+             */
+            self.INIT = "init",
+
+            /**
+             * @const
+             */
+                self.INDEX = "index",
+
+            /**
+             * @const
+             */
+                self.REINDEX = "reindex",
+
+            /**
+             * @const
+             */
+                self.UNINDEX = "unindex",
+
+            /**
+             * @const
+             */
+                self.REINDEXALL = "reindexAll",
+
+            /**
+             * @const
+             */
+                self.UNINDEXALL = "unindexAll";
+
+        }
+
+        return OperationEnum;
+    }
+);
+
+
+/**
+ * Module representing an Indexing Operation Resource.
+ * @exports indexingOperationResource
+ */
+define('indexingOperationResource', ['SHARED/jquery'],
+    function($) {
+
+
+        var AnIndexingOperationResource = function AnIndexingOperationResource() {
+            var self = this;
+
+            /**
+             * The Entity Type
+             * datatype: String
+             **/
+            self.entityType = null;
+
+            /**
+             * The Entity Id
+             * datatype: String
+             **/
+            self.entityId = null;
+
+            /**
+             * The Indexing operation
+             * datatype: OperationEnum
+             **/
+            self.operation = null;
+
+
+            self.constructFromObject = function(data) {
+
+                self.entityType = data.entityType;
+
+                self.entityId = data.entityId;
+
+                self.operation = data.operation;
+
+            }
+
+
+            /**
+             * get The Entity Type
+             * @return {String}
+             **/
+            self.getEntityType = function() {
+                return self.entityType;
+            }
+
+            /**
+             * set The Entity Type
+             * @param {String} entityType
+             **/
+            self.setEntityType = function (entityType) {
+                self.entityType = entityType;
+            }
+
+            /**
+             * get The Entity Id
+             * @return {String}
+             **/
+            self.getEntityId = function() {
+                return self.entityId;
+            }
+
+            /**
+             * set The Entity Id
+             * @param {String} entityId
+             **/
+            self.setEntityId = function (entityId) {
+                self.entityId = entityId;
+            }
+
+            /**
+             * get The Indexing operation
+             * @return {OperationEnum}
+             **/
+            self.getOperation = function() {
+                return self.operation;
+            }
+
+            /**
+             * set The Indexing operation
+             * @param {OperationEnum} operation
+             **/
+            self.setOperation = function (operation) {
+                self.operation = operation;
+            }
+
+
+            self.toJson = function () {
+                return JSON.stringify(self);
+            }
+        }
+
+        return AnIndexingOperationResource;
+    }
+);

--- a/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/styles/indexingManagement.less
+++ b/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/assets/styles/indexingManagement.less
@@ -1,0 +1,131 @@
+.indexing-service-management {
+
+  //Main
+
+  padding: 10px;
+
+  // Page Header
+
+  .page-header {
+    padding-bottom: 9px;
+    margin: 40px 0 20px;
+    border-bottom: 1px solid #eee;
+  }
+
+  .h1, h1 {
+    font-size: 36px;
+  }
+
+  // Connectors numbers
+
+  .connector-number-stat {
+    background-color: #3F7577;
+    color: #fff;
+    padding: 5px 20px 0 20px;
+    border-radius: 4px;
+  }
+
+  // Indexing Operations number
+
+  .operation-number-stat {
+    background-color: #67773F;
+    color: #fff;
+    padding: 5px 20px 0 20px;
+    border-radius: 4px;
+  }
+
+  // Indexing Error number
+
+  .error-number-stat {
+    background-color: #D36B19;
+    color: #fff;
+    padding: 5px 20px 0 20px;
+    border-radius: 4px;
+  }
+
+  // Big Number
+
+  .big-number-data {
+    float: left;
+    margin-bottom: 0;
+  }
+
+  .big-number-stat .col-left {
+    float: left;
+    margin-right: 10px;
+    line-height: 1.8;
+  }
+
+  .big-number-stat .col-right {
+    float: right;
+    position: relative;
+    top: 1.5em;
+  }
+
+  .big-number-stat span {
+    display: inline-block;
+    vertical-align: middle;
+  }
+
+  .big-number {
+    font-size: 3.5em;
+  }
+
+  .big-number-stat em {
+    display: block;
+    font-style: italic;
+  }
+
+  .big-number-stat p {
+    margin: 0px;
+    font-size: 20px;
+  }
+
+  //Panel is not available in bootstrap 2.3
+
+  .panel {
+    margin-top: 20px;
+    background-color: #fff;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
+    box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
+  }
+  .panel-body {
+    padding: 15px;
+    border-color: grey;
+    border-bottom: 1px solid #ddd;
+  }
+  .panel-heading {
+    padding: 10px 15px;
+    border-bottom: 1px solid transparent;
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
+    font-size: 15px;
+    font-weight: bold
+  }
+
+  .panel > .table,
+  .panel > .table-responsive > .table,
+  .panel > .panel-collapse > .table {
+    margin-bottom: 0;
+  }
+  .panel-default {
+    border-color: #ddd;
+  }
+  .panel-default > .panel-heading {
+    color: #333;
+    background-color: #f5f5f5;
+    border-color: #ddd;
+  }
+  .panel-default > .panel-heading + .panel-collapse > .panel-body {
+    border-top-color: #ddd;
+  }
+  .panel-default > .panel-heading .badge {
+    color: #f5f5f5;
+    background-color: #333;
+  }
+  .panel-default > .panel-footer + .panel-collapse > .panel-body {
+    border-bottom-color: #ddd;
+  }
+}

--- a/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/package-info.java
+++ b/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/package-info.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013 eXo Platform SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@juzu.Application(defaultController = IndexingManagementApplication.class)
+@Portlet
+@Scripts({
+    @Script(id = "apiClient", value = "scripts/rest/client/ApiClient.js"),
+    @Script(id = "indexingOperationResource", value = "scripts/rest/model/AnIndexingOperationResource.js"),
+    @Script(id = "indexingConnectorResources", value = "scripts/rest/model/AnIndexingConnectorResources.js"),
+    @Script(id = "indexingManagementApi" , value = "scripts/rest/api/VindexingManagementApi.js"),
+    @Script(id = "statController" , value = "scripts/app/controller/statController.js"),
+    @Script(id = "connectorController" , value = "scripts/app/controller/connectorController.js"),
+    @Script(id = "operationController" , value = "scripts/app/controller/operationController.js"),
+    @Script(id = "appBroadcaster" , value = "scripts/app/broadcaster.js"),
+    @Script(id = "main" , value = "scripts/app/main.js")
+})
+@Less({
+    @Stylesheet(id = "indexingManagement-less", value = "styles/indexingManagement.less")
+})
+@Assets("*")
+package org.exoplatform.search.portlet.indexing.management;
+
+import juzu.plugin.asset.Assets;
+import juzu.plugin.asset.Script;
+import juzu.plugin.asset.Scripts;
+import juzu.plugin.asset.Stylesheet;
+import juzu.plugin.less4j.Less;
+import juzu.plugin.portlet.Portlet;

--- a/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/templates/indexingManagement.gtmpl
+++ b/extension/webapp/src/main/java/org/exoplatform/search/portlet/indexing/management/templates/indexingManagement.gtmpl
@@ -1,0 +1,102 @@
+<div id = "indexingManagement" class="indexing-service-management">
+
+    <!-- Title -->
+    <h1 class="page-header">Indexing Service Management Application</h1>
+
+    <!-- Stats -->
+    <div class="row-fluid indexing-stat">
+        <div class="span12">
+            <div class="row-fluid">
+                <div class="span4">
+                    <div class="connector-number-stat big-number-stat clearfix">
+                        <div class="big-number-data">
+                            <span class="col-left big-number" id="statNbConnector"></span>
+                            <span class="col-right">
+                                <p>Connectors</p>
+                                <em> registered</em>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+                <div class="span4">
+                    <div class="operation-number-stat big-number-stat clearfix">
+                        <div class="big-number-data">
+                            <span class="col-left big-number" id="statNbOperation"></span>
+                            <span class="col-right">
+                                <p>Operations</p>
+                                <em> in queue</em>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+                <div class="span4">
+                    <div class="error-number-stat big-number-stat clearfix">
+                        <div class="big-number-data">
+                            <span class="col-left big-number" id="statNbError"></span>
+                            <span class="col-right">
+                                <p>Errors</p>
+                                <em> catched</em>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Connector List -->
+    <div class="row-fluid indexing-connector-list">
+        <div class="span12">
+            <div class="panel panel-default">
+                <!-- Default panel contents -->
+                <div class="panel-heading">Indexing Connector Management</div>
+                <div class="panel-body">
+                    <p>List of all Indexing connectors currently register to the Indexing Service.
+                    You can can take some action such as disable/enable a connector or run a full reindexing.</p>
+                </div>
+                <table class="table" id="indexingConnectorTable">
+                    <thead>
+                    <tr>
+                        <th>Type</th>
+                        <th>Description</th>
+                        <th>Index</th>
+                        <th>State</th>
+                        <th>Actions</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <!-- Indexing Operation List -->
+    <div class="row-fluid indexing-operation-list">
+        <div class="span12">
+            <div class="panel panel-default">
+                <!-- Default panel contents -->
+                <div class="panel-heading">Operation Indexing Management</div>
+                <div class="panel-body">
+                    <p>List of all indexing operations.</p>
+                </div>
+                <table class="table" id="indexingOperationTable">
+                    <thead>
+                    <tr>
+                        <th>Id</th>
+                        <th>Type</th>
+                        <th>Entity Id</th>
+                        <th>Operation</th>
+                        <th>Timestamp</th>
+                        <th>Actions</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+</div>

--- a/extension/webapp/src/main/resources/beans.xml
+++ b/extension/webapp/src/main/resources/beans.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/extension/webapp/src/main/webapp/WEB-INF/conf/portal/group/platform/administrators/navigation.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/portal/group/platform/administrators/navigation.xml
@@ -100,5 +100,11 @@
             <label>#{administration.notification}</label>
             <page-reference>group::/platform/administrators::notification</page-reference>
         </node>
+        <node>
+            <uri>searchIndexing</uri>
+            <name>searchIndexing</name>
+            <label>Search Indexing</label>
+            <page-reference>group::/platform/administrators::searchIndexing</page-reference>
+        </node>
     </page-nodes>
 </node-navigation>

--- a/extension/webapp/src/main/webapp/WEB-INF/conf/portal/group/platform/administrators/pages.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/portal/group/platform/administrators/pages.xml
@@ -265,4 +265,19 @@
       <show-application-mode>false</show-application-mode>
     </portlet-application>
   </page>
+    <page>
+        <name>searchIndexing</name>
+        <title>Search Indexing</title>
+        <access-permissions>*:/platform/administrators</access-permissions>
+        <edit-permission>*:/platform/administrators</edit-permission>
+        <show-max-window>false</show-max-window>
+        <portlet-application>
+            <portlet>
+                <application-ref>platform-extension</application-ref>
+                <portlet-ref>SearchIndexingManagement</portlet-ref>
+            </portlet>
+            <access-permissions>*:/platform/administrators</access-permissions>
+            <show-info-bar>false</show-info-bar>
+        </portlet-application>
+    </page>
 </page-set>

--- a/extension/webapp/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<jboss-web>
+  <resource-ref>
+    <description>DB Connection</description>
+    <res-ref-name>exo-jpa_portal</res-ref-name>
+    <res-type>javax.sql.DataSource</res-type>
+    <res-auth>Container</res-auth>
+    <jndi-name>java:/comp/env/exo-jpa_portal</jndi-name>
+  </resource-ref>
+</jboss-web>

--- a/extension/webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<portlet-app xmlns="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd"
+             version="2.0"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd
+   http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd">
+   <portlet>
+     <portlet-name>SearchIndexingManagement</portlet-name>
+     <display-name xml:lang="EN">eXo Elastic Indexing Management Application</display-name>
+     <portlet-class>juzu.bridge.portlet.JuzuPortlet</portlet-class>
+     <init-param>
+       <name>juzu.app_name</name>
+       <value>org.exoplatform.search.portlet.indexing.management</value>
+     </init-param>
+     <supports>
+       <mime-type>text/html</mime-type>
+     </supports>
+     <portlet-info>
+       <title>eXo Search Indexing Management Application</title>
+     </portlet-info>
+   </portlet>
+</portlet-app>

--- a/extension/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/web.xml
@@ -30,7 +30,19 @@
   <display-name>platform-extension</display-name>
 
   <absolute-ordering />
-  
+
+  <!-- Run mode: prod, dev or live -->
+  <context-param>
+    <param-name>juzu.run_mode</param-name>
+    <param-value>${juzu.run_mode:prod}</param-value>
+  </context-param>
+
+  <!-- Injection container to use: guice, spring, cdi or weld -->
+  <context-param>
+    <param-name>juzu.inject</param-name>
+    <param-value>guice</param-value>
+  </context-param>
+
   <filter>
     <filter-name>LocalizationFilter</filter-name>
     <filter-class>org.exoplatform.portal.application.localization.LocalizationFilter</filter-class>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <org.exoplatform.integ.version>4.4.x-SNAPSHOT</org.exoplatform.integ.version>
     <org.exoplatform.platform-ui.version>4.4.x-SNAPSHOT</org.exoplatform.platform-ui.version>
 
+    <juzu.version>1.1.0</juzu.version>
   </properties>
   <dependencyManagement>
     <!-- ### NEVER CHANGE THIS ORDER OF DEPMGT ### -->
@@ -764,6 +765,21 @@
         <groupId>org.gatein.web</groupId>
         <artifactId>redirect</artifactId>
         <version>${org.gatein.portal.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.juzu</groupId>
+        <artifactId>juzu-plugins-validation</artifactId>
+        <version>${juzu.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.juzu</groupId>
+        <artifactId>juzu-plugins-less4j</artifactId>
+        <version>${juzu.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.juzu</groupId>
+        <artifactId>juzu-plugins-webjars</artifactId>
+        <version>${juzu.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This PR adds the Search Indexing Management portlet in platform extension war (it avoids a new war, and all others platform portlets will probably end here).
The name of the portlet has been changed from the addon. I think it is fine since we have no customers using this portlet (it was not a supported addon), and anyway the war name containing will change so the portlet reference will change.
It also adds the administration menu for this portlet.