### PR TITLE
PLF-7083 [Remote edit] Invalid format when saving document .docx with…

### DIFF
--- a/extension/webapp/src/main/webapp/WEB-INF/conf/platform/dms/dms-configuration.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/platform/dms/dms-configuration.xml
@@ -76,22 +76,8 @@
 
       <values-param>
           <name>untrusted-user-agents</name>
-          <value>Microsoft Office Core Storage Infrastructure/1.0</value>
-          <value>gvfs/1.20.1</value><!-- Ubuntu 14.04 LTS -->
-          <value>gvfs/1.20.2</value><!-- Ubuntu 14.10 -->
-          <value>gvfs/1.20.3</value><!-- Ubuntu 14.04.2 LTS -->
-          <value>Microsoft Office Excel 2013</value>
-          <value>Microsoft Office Word 2013</value>
-          <value>Microsoft Office PowerPoint 2013</value>
-          <value>Microsoft Office Word 2013 (15.0.4701) Windows NT 6.1</value>
-          <value>Microsoft Office Excel 2013 (15.0.4701) Windows NT 6.1</value>
-          <value>Microsoft Office PowerPoint 2013 (15.0.4701) Windows NT 6.1</value>
-          <value>Microsoft Office Word 2013 (15.0.4763) Windows NT 10.0</value>
-          <value>Microsoft Office Excel 2013 (15.0.4763) Windows NT 10.0</value>
-          <value>Microsoft Office PowerPoint 2013 (15.0.4763) Windows NT 10.0</value>
-          <value>Microsoft Office Word 2016 (16.0.6868.2060) Windows NT 10.0</value>
-          <value>Microsoft Office Excel 2016 (16.0.6868.2060) Windows NT 10.0</value>
-          <value>Microsoft Office PowerPoint 2016 (16.0.6868.2060) Windows NT 10.0</value>
+          <value>gvfs/*</value>
+          <value>Microsoft Office .*</value>
       </values-param>
 
     </init-params>


### PR DESCRIPTION
… Microsoft Office 2016 in Windows 10

This fix uses the improvements made in JCR-2385 that consists of making the mediaType calculated using file extension instead of mediaType sent by MSOffice. The fix of JCR-2385 introduces the use of UserAgents patterns instead of embedded values.