### PR TITLE
PLF-7529 : Add Unique key on IDM tables

### DIFF
--- a/component/organization/pom.xml
+++ b/component/organization/pom.xml
@@ -61,6 +61,10 @@
       <artifactId>commons-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
     </dependency>

--- a/component/organization/src/main/java/org/exoplatform/platform/organization/checker/IDMDataRepair.java
+++ b/component/organization/src/main/java/org/exoplatform/platform/organization/checker/IDMDataRepair.java
@@ -1,0 +1,106 @@
+package org.exoplatform.platform.organization.checker;
+
+import liquibase.change.custom.CustomTaskChange;
+import liquibase.database.Database;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.CustomChangeException;
+import liquibase.exception.SetupException;
+import liquibase.exception.ValidationErrors;
+import liquibase.resource.ResourceAccessor;
+import org.exoplatform.services.database.utils.JDBCUtils;
+
+import java.sql.Connection;
+import java.util.Map;
+
+/**
+ * Liquibase task to detect and clean duplicated idm entries
+ */
+public abstract class IDMDataRepair implements CustomTaskChange {
+
+    private String tableName;
+
+    @Override
+    public void execute(Database database) throws CustomChangeException {
+        JdbcConnection dbConn = (JdbcConnection) database.getConnection();
+
+        //If table exist check and clean duplicated entries before
+        // add the Unique key by hibernate DLL
+        if (tableExists(tableName, dbConn.getWrappedConnection())) {
+            Map<Integer, Integer> duplicatedItems = null;
+            try {
+                duplicatedItems = findDuplicatedItems();
+                for (Integer id : duplicatedItems.keySet()) {
+                    updateRelatedItems(id, duplicatedItems.get(id));
+                }
+            } catch (IDMRepairException e) {
+                throw new CustomChangeException(e.getMessage());
+            } finally {
+                for (Integer id : duplicatedItems.keySet()) {
+                    try {
+                        removeDuplicatedItems(id);
+                    } catch (IDMRepairException e) {
+                        throw new CustomChangeException(e.getMessage());
+                    }
+                }
+            }
+
+        }
+    }
+
+    @Override
+    public String getConfirmationMessage() {
+        return null;
+    }
+
+    @Override
+    public void setUp() throws SetupException {
+
+    }
+
+    @Override
+    public void setFileOpener(ResourceAccessor resourceAccessor) {
+
+    }
+
+    /**
+     * Find the list of duplicated entries
+     * @return the list of duplicated items
+     * @throws IDMRepairException
+     */
+    protected abstract Map<Integer, Integer> findDuplicatedItems() throws IDMRepairException;
+
+    /**
+     * Update the list of the tables reference the duplicated entries
+     * @param id
+     * @param maxID
+     * @return
+     * @throws IDMRepairException
+     */
+    protected abstract boolean updateRelatedItems(int id, int maxID) throws IDMRepairException;
+
+    /***
+     * remove the liste of duplicated entries
+     * @param id
+     * @return
+     * @throws IDMRepairException
+     */
+    protected abstract boolean removeDuplicatedItems(int id) throws IDMRepairException;
+
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return null;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public boolean tableExists(String tableName, Connection con) {
+        return JDBCUtils.tableExists(tableName, con);
+    }
+}

--- a/component/organization/src/main/java/org/exoplatform/platform/organization/checker/IDMInspectionQuery.java
+++ b/component/organization/src/main/java/org/exoplatform/platform/organization/checker/IDMInspectionQuery.java
@@ -1,0 +1,179 @@
+package org.exoplatform.platform.organization.checker;
+
+import liquibase.database.jvm.JdbcConnection;
+
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * Utility class contain the list of inspect and repair queries
+ */
+public class IDMInspectionQuery {
+
+    private static final Log LOG                            = ExoLogger.getLogger(IDMInspectionQuery.class);
+
+
+    /**
+     * Table jbid_realm
+     */
+    //1-Find duplicated query
+    protected static String FIND_DUPLICATED_JBID_REALM = "select max(ID) max ,NAME, count(*)"
+            + "   FROM jbid_realm group by NAME having count(*) > 1";
+
+    protected static String FIND_ITEM_JBID_REALM_BY_NAME = "select ID from jbid_realm where NAME=? and ID < ?";
+
+    //2-update related table query
+    protected static String UPDATE_REALM_JBID_IO_REL_NAME = "update jbid_io_rel_name set REALM=? where REALM IN ?";
+
+    protected static String UPDATE_REALM_JBID_PROPS_REL = "update jbid_io_rel_props set PROP_ID=? where PROP_ID IN ?";
+
+    protected static String UPDATE_REALM_JBID_IO = "update jbid_io set REALM=? where REALM IN ?";
+
+    //3-remove duplicated query
+    protected static String REMOVE_DUPLICATED_JBID_REALM = "remove from jbid_realm where ID IN ?";
+
+
+    /**
+     * Table jbid_io_creden
+     */
+    //1-Find duplicated query
+    protected static String FIND_DUPLICATED_JBID_CREDEN = "select max(ID) max ,IDENTITY_OBJECT_ID, CREDENTIAL_TYPE, count(*)"
+            + "   FROM jbid_io_creden group by IDENTITY_OBJECT_ID, CREDENTIAL_TYPE having count(*) > 1";
+
+    protected static String FIND_ITEM_JBID_CREDEN_BY_KEY = "select ID from jbid_io_creden where"
+            + " IDENTITY_OBJECT_ID= ? and CREDENTIAL_TYPE= ? and ID < ?";
+
+    //2-update related table query
+    //TODO
+
+    //3-remove duplicated query
+    //TODO
+
+    /**
+     * Table jbid_io_attr
+     */
+    //1-Find duplicated query
+    protected static String FIND_DUPLICATED_JBID_ATTR = "select max(ATTRIBUTE_ID) max ,IDENTITY_OBJECT_ID, NAME, count(*)"
+            + "   FROM jbid_io_attr group by IDENTITY_OBJECT_ID, NAME having count(*) > 1";
+
+
+    //2-update related table query
+    //TODO
+
+    //3-remove duplicated query
+    //TODO
+
+    /**
+     * Table jbid_io_rel_name
+     */
+    //1-Find duplicated query
+    protected static String FIND_DUPLICATED_JBID_REL_NAME = "select max(ID) max ,NAME, REALM, count(*)   FROM jbid_io_rel_name"
+            + " group by NAME, REALM having count(*) > 1";
+
+    protected static String FIND_ITEM_JBID_REL_NAME =  "select ID from jbid_io_rel_name where NAME = ? and REALM = ? and ID < ?";
+
+
+    //2-update related table query
+    //TODO
+
+    //3-remove duplicated query
+    //TODO
+
+    /**
+     * Table jbid_io_rel
+     */
+    //1-Find duplicated query
+    protected static String FIND_DUPLICATED_JBID_REL = "select max(ID) max ,FROM_IDENTITY, NAME, TO_IDENTITY, REL_TYPE,  count(*)"
+            + "   FROM jbid_io_rel group by FROM_IDENTITY, NAME, TO_IDENTITY, REL_TYPE having count(*) > 1";
+
+
+
+    //2-update related table query
+    //TODO
+
+    //3-remove duplicated query
+    //TODO
+
+    /**
+     * Prepared Statement
+     */
+    protected PreparedStatement findDuplicatedRealm;
+
+    protected PreparedStatement findDuplicatedCreden;
+
+    protected PreparedStatement findDuplicatedAttr;
+
+    protected PreparedStatement findDuplicatedRel;
+
+    protected PreparedStatement findDuplicatedRelName;
+
+
+    public ResultSet findDuplicatedRealm(JdbcConnection connection) throws IDMRepairException{
+        try(PreparedStatement findDuplicatedRealm_ = connection.prepareStatement(FIND_DUPLICATED_JBID_REALM)
+        ) {
+            findDuplicatedRealm = findDuplicatedRealm_;
+            ResultSet result = findDuplicatedRealm.executeQuery();
+            return result;
+        } catch (Exception e) {
+            LOG.error("Error to get duplicated items on Realm table " + e.getMessage(), e);
+            throw new IDMRepairException(e.getMessage());
+        }
+    }
+
+    public ResultSet findDuplicatedCreden(JdbcConnection connection) throws IDMRepairException{
+        try(PreparedStatement findDuplicatedCreden_ = connection.prepareStatement(FIND_DUPLICATED_JBID_CREDEN)
+        ) {
+            findDuplicatedCreden = findDuplicatedCreden_;
+            ResultSet result = findDuplicatedCreden.executeQuery();
+            return result;
+        } catch (Exception e) {
+            LOG.error("Error to get duplicated items on Creden table" + e.getMessage(), e);
+            throw new IDMRepairException(e.getMessage());
+
+        }
+    }
+
+    public ResultSet findDuplicatedAttr(JdbcConnection connection) throws IDMRepairException{
+        try(PreparedStatement findDuplicatedAttr_ = connection.prepareStatement(FIND_DUPLICATED_JBID_ATTR)
+        ) {
+            findDuplicatedAttr = findDuplicatedAttr_;
+            ResultSet result = findDuplicatedAttr.executeQuery();
+            return result;
+        } catch (Exception e) {
+            LOG.error("Error to get duplicated items on Attr table" + e.getMessage(), e);
+            throw new IDMRepairException(e.getMessage());
+
+        }
+    }
+
+    public ResultSet findDuplicatedRel(JdbcConnection connection) throws IDMRepairException{
+        try(PreparedStatement findDuplicatedRel_ = connection.prepareStatement(FIND_DUPLICATED_JBID_REL_NAME)
+        ) {
+            findDuplicatedRel = findDuplicatedRel_;
+            ResultSet result = findDuplicatedRel.executeQuery();
+            return result;
+        } catch (Exception e) {
+            LOG.error("Error to get duplicated items Rel table" + e.getMessage(), e);
+            throw new IDMRepairException(e.getMessage());
+
+        }
+    }
+
+    public ResultSet findDuplicatedRelName(JdbcConnection connection) throws IDMRepairException{
+        try(PreparedStatement findDuplicatedRelName_ = connection.prepareStatement(FIND_DUPLICATED_JBID_ATTR)
+        ) {
+            findDuplicatedRelName = findDuplicatedRelName_;
+            ResultSet result = findDuplicatedRelName.executeQuery();
+            return result;
+        } catch (Exception e) {
+            LOG.error("Error to get duplicated items on Rel Name table" + e.getMessage(), e);
+            throw new IDMRepairException(e.getMessage());
+
+        }
+    }
+
+
+}

--- a/component/organization/src/main/java/org/exoplatform/platform/organization/checker/IDMRepairException.java
+++ b/component/organization/src/main/java/org/exoplatform/platform/organization/checker/IDMRepairException.java
@@ -1,0 +1,22 @@
+package org.exoplatform.platform.organization.checker;
+
+/**
+ *  IDM repair data exception
+ */
+public class IDMRepairException extends Exception {
+
+    public IDMRepairException() {
+    }
+
+    public IDMRepairException(String message) {
+        super(message);
+    }
+
+    public IDMRepairException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public IDMRepairException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/component/organization/src/main/java/org/exoplatform/platform/organization/checker/impl/JbidAttrRepair.java
+++ b/component/organization/src/main/java/org/exoplatform/platform/organization/checker/impl/JbidAttrRepair.java
@@ -1,0 +1,29 @@
+package org.exoplatform.platform.organization.checker.impl;
+
+import org.exoplatform.platform.organization.checker.IDMDataRepair;
+import org.exoplatform.platform.organization.checker.IDMRepairException;
+
+import java.util.Map;
+
+/**
+ * Repair jbid_io_attr utility class
+ */
+public class JbidAttrRepair extends IDMDataRepair {
+    @Override
+    protected Map<Integer, Integer> findDuplicatedItems() throws IDMRepairException {
+        //TODO
+        return null;
+    }
+
+    @Override
+    protected boolean updateRelatedItems(int id, int maxID) throws IDMRepairException {
+        //TODO
+        return true;
+    }
+
+    @Override
+    protected boolean removeDuplicatedItems(int id) throws IDMRepairException {
+        //TODO
+        return true;
+    }
+}

--- a/component/organization/src/main/java/org/exoplatform/platform/organization/checker/impl/JbidCredenRepair.java
+++ b/component/organization/src/main/java/org/exoplatform/platform/organization/checker/impl/JbidCredenRepair.java
@@ -1,0 +1,29 @@
+package org.exoplatform.platform.organization.checker.impl;
+
+import org.exoplatform.platform.organization.checker.IDMDataRepair;
+import org.exoplatform.platform.organization.checker.IDMRepairException;
+
+import java.util.Map;
+
+/**
+ * Repair jbid_io_creden utility class
+ */
+public class JbidCredenRepair extends IDMDataRepair {
+    @Override
+    protected Map<Integer, Integer> findDuplicatedItems() throws IDMRepairException {
+        //TODO
+        return null;
+    }
+
+    @Override
+    protected boolean updateRelatedItems(int id, int maxID) throws IDMRepairException {
+        //TODO
+        return true;
+    }
+
+    @Override
+    protected boolean removeDuplicatedItems(int id) throws IDMRepairException {
+        //TODO
+        return true;
+    }
+}

--- a/component/organization/src/main/java/org/exoplatform/platform/organization/checker/impl/JbidRealmRepair.java
+++ b/component/organization/src/main/java/org/exoplatform/platform/organization/checker/impl/JbidRealmRepair.java
@@ -1,0 +1,29 @@
+package org.exoplatform.platform.organization.checker.impl;
+
+import org.exoplatform.platform.organization.checker.IDMDataRepair;
+import org.exoplatform.platform.organization.checker.IDMRepairException;
+
+import java.util.Map;
+
+/**
+ * Repair jbid_realm utility class
+ */
+public class JbidRealmRepair extends IDMDataRepair {
+    @Override
+    protected Map<Integer, Integer> findDuplicatedItems() throws IDMRepairException {
+        //TODO
+        return null;
+    }
+
+    @Override
+    protected boolean updateRelatedItems(int id, int maxID) throws IDMRepairException {
+        //TODO
+        return true;
+    }
+
+    @Override
+    protected boolean removeDuplicatedItems(int id) throws IDMRepairException {
+        //TODO
+        return true;
+    }
+}

--- a/component/organization/src/main/java/org/exoplatform/platform/organization/checker/impl/JbidRelNameRepair.java
+++ b/component/organization/src/main/java/org/exoplatform/platform/organization/checker/impl/JbidRelNameRepair.java
@@ -1,0 +1,29 @@
+package org.exoplatform.platform.organization.checker.impl;
+
+import org.exoplatform.platform.organization.checker.IDMDataRepair;
+import org.exoplatform.platform.organization.checker.IDMRepairException;
+
+import java.util.Map;
+
+/**
+ * Repair jbid_io_rel_name utility class
+ */
+public class JbidRelNameRepair extends IDMDataRepair {
+    @Override
+    protected Map<Integer, Integer> findDuplicatedItems() throws IDMRepairException {
+        //TODO
+        return null;
+    }
+
+    @Override
+    protected boolean updateRelatedItems(int id, int maxID) throws IDMRepairException {
+        //TODO
+        return true;
+    }
+
+    @Override
+    protected boolean removeDuplicatedItems(int id) throws IDMRepairException {
+        //TODO
+        return true;
+    }
+}

--- a/component/organization/src/main/java/org/exoplatform/platform/organization/checker/impl/JbidRelRepair.java
+++ b/component/organization/src/main/java/org/exoplatform/platform/organization/checker/impl/JbidRelRepair.java
@@ -1,0 +1,29 @@
+package org.exoplatform.platform.organization.checker.impl;
+
+import org.exoplatform.platform.organization.checker.IDMDataRepair;
+import org.exoplatform.platform.organization.checker.IDMRepairException;
+
+import java.util.Map;
+
+/**
+ * Repair jbid_io_rel utility class.
+ */
+public class JbidRelRepair extends IDMDataRepair {
+    @Override
+    protected Map<Integer, Integer> findDuplicatedItems() throws IDMRepairException {
+        //TODO
+        return null;
+    }
+
+    @Override
+    protected boolean updateRelatedItems(int id, int maxID) throws IDMRepairException {
+        //TODO
+        return true;
+    }
+
+    @Override
+    protected boolean removeDuplicatedItems(int id) throws IDMRepairException {
+        //TODO
+        return true;
+    }
+}

--- a/component/organization/src/main/resources/changelog/idm.db.changelog-1.0.0.xml
+++ b/component/organization/src/main/resources/changelog/idm.db.changelog-1.0.0.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+  <changeSet id="1.0.0-1" author="idm" dbms="oracle,postgresql,mssql">
+    <customChange class="org.exoplatform.platform.organization.checker.impl.JbidRealmRepair">
+      <param name="tableName" value="jbid_realm"></param>
+    </customChange>
+  </changeSet>
+  <changeSet id="1.0.0-2" author="idm" dbms="oracle,postgresql,mssql">
+    <customChange class="org.exoplatform.platform.organization.checker.impl.jbid_realm">
+      <param name="tableName" value="jbid_io_attr"></param>
+    </customChange>
+  </changeSet>
+  <changeSet id="1.0.0-3" author="idm" dbms="oracle,postgresql,mssql">
+    <customChange class="org.exoplatform.platform.organization.checker.impl.JbidCredenRepair">
+      <param name="tableName" value="jbid_io_creden"></param>
+    </customChange>
+  </changeSet>
+  <changeSet id="1.0.0-4" author="idm" dbms="oracle,postgresql,mssql">
+    <customChange class="org.exoplatform.platform.organization.checker.impl.JbidRelRepair">
+      <param name="tableName" value="jbid_io_rel"></param>
+    </customChange>
+  </changeSet>
+  <changeSet id="1.0.0-5" author="idm" dbms="oracle,postgresql,mssql">
+    <customChange class="org.exoplatform.platform.organization.checker.impl.JbidRelNameRepair">
+      <param name="tableName" value="jbid_io_rel_name"></param>
+    </customChange>
+  </changeSet>
+</databaseChangeLog>

--- a/component/organization/src/main/resources/conf/configuration.xml
+++ b/component/organization/src/main/resources/conf/configuration.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  ~ /*
+  ~  * Copyright (C) 2003-2015 eXo Platform SAS.
+  ~  *
+  ~  * This program is free software; you can redistribute it and/or
+  ~ * modify it under the terms of the GNU Affero General Public License
+  ~ * as published by the Free Software Foundation; either version 3
+  ~ * of the License, or (at your option) any later version.
+  ~ *
+  ~ * This program is distributed in the hope that it will be useful,
+  ~ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ * GNU General Public License for more details.
+  ~ *
+  ~ * You should have received a copy of the GNU General Public License
+  ~ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+  ~  */
+  -->
+
+<configuration
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+        xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <!-- Data Initialization -->
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
+    <component-plugin>
+      <name>WikiChangeLogsPlugin</name>
+      <set-method>addChangeLogsPlugin</set-method>
+      <type>org.exoplatform.commons.persistence.impl.ChangeLogsPlugin</type>
+      <init-params>
+        <values-param>
+          <name>changelogs</name>
+          <description>Change logs of wiki</description>
+          <value>changelog/idm.db.changelog-1.0.0.xml</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+</configuration>

--- a/extension/webapp/src/main/webapp/WEB-INF/conf/organization/idm-configuration.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/organization/idm-configuration.xml
@@ -325,20 +325,6 @@
           <value>picketlink-idm/mappings/HibernateIdentityObjectRelationshipType.hbm.xml</value>
           <value>picketlink-idm/mappings/HibernateIdentityObjectRelationshipName.hbm.xml</value>
         </values-param>
-        <values-param profiles="sybase">
-          <name>hibernate.mapping</name>
-          <value>picketlink-idm/sybase-mappings/HibernateRealm.hbm.xml</value>
-          <value>picketlink-idm/sybase-mappings/HibernateIdentityObjectCredentialBinaryValue.hbm.xml</value>
-          <value>picketlink-idm/sybase-mappings/HibernateIdentityObjectAttributeBinaryValue.hbm.xml</value>
-          <value>picketlink-idm/sybase-mappings/HibernateIdentityObject.hbm.xml</value>
-          <value>picketlink-idm/sybase-mappings/HibernateIdentityObjectCredential.hbm.xml</value>
-          <value>picketlink-idm/sybase-mappings/HibernateIdentityObjectCredentialType.hbm.xml</value>
-          <value>picketlink-idm/sybase-mappings/HibernateIdentityObjectAttribute.hbm.xml</value>
-          <value>picketlink-idm/sybase-mappings/HibernateIdentityObjectType.hbm.xml</value>
-          <value>picketlink-idm/sybase-mappings/HibernateIdentityObjectRelationship.hbm.xml</value>
-          <value>picketlink-idm/sybase-mappings/HibernateIdentityObjectRelationshipType.hbm.xml</value>
-          <value>picketlink-idm/sybase-mappings/HibernateIdentityObjectRelationshipName.hbm.xml</value>
-        </values-param>
       </init-params>
     </component-plugin>
   </external-component-plugins>


### PR DESCRIPTION
This PR contains the process to clean duplicated IDM entries before add Unique key constraint.
For each table :+1: 
* Find duplicated entries
* Update related tables
* remove duplicated entries