### PR TITLE
ECMS-7707 : manage the case of no preview for webcontents

### DIFF
--- a/extension/webapp/src/main/webapp/javascript/document-preview.js
+++ b/extension/webapp/src/main/webapp/javascript/document-preview.js
@@ -1095,7 +1095,7 @@
 
     // Show empty preview message
     var $blockToAppendTo = $uiDocumentPreview.find(".UIResizableBlock");
-    if($blockToAppendTo.length == 0) {
+    if($blockToAppendTo.length == 0 && !documentPreview.settings.doc.isWebContent) {
       $blockToAppendTo = $("#documentPreviewContent");
       if($blockToAppendTo.find(".EmptyDocumentPreview").length == 0) {
         $blockToAppendTo.append("<div class='EmptyDocumentPreview'><div class='message'><div class='content'><i class='" + documentPreview.settings.doc.cssIcon + "'></i><br><span>${UIActivity.comment.noPreviewOfDocument}</span></div></div></div>");


### PR DESCRIPTION
When previewing a webcontent, the div with the class UIResizableBlock does not exist (it is rendered by the file template), so it considered there were no preview.
This PR adds a check on the flag isWebContent to prevent this issue.