### PR TITLE
PLF-7940 : Add language Czech and remove Vietnamese

### DIFF
--- a/extension/webapp/src/main/webapp/WEB-INF/conf/common/locales-config.xml
+++ b/extension/webapp/src/main/webapp/WEB-INF/conf/common/locales-config.xml
@@ -48,12 +48,12 @@
     <input-encoding>UTF-8</input-encoding>
     <description>Default configuration for the spanish locale</description>
   </locale-config>
-  
+
   <locale-config>
-    <locale>vi</locale>
+    <locale>cs</locale>
     <output-encoding>UTF-8</output-encoding>
     <input-encoding>UTF-8</input-encoding>
-    <description>Default configuration for the vietnamese locale</description>
+    <description>Default configuration for the Czech locale</description>
   </locale-config>
 
   <locale-config>


### PR DESCRIPTION
Add language Czech and remove Vietnamese.

I did not remove the vietnamese language in all others files since it is not useful and will make it easier in the future if we want to add it back (as we did for Czech here).