### PR TITLE
PLF-8239 : add missing variable in exo-sample.properties

### DIFF
--- a/extension/config/src/main/resources/conf/platform/configuration.properties
+++ b/extension/config/src/main/resources/conf/platform/configuration.properties
@@ -924,6 +924,31 @@ exo.quartz.dataSource.quartzDS.jndiURL=${exo.quartz.dataSource.quartzDS.jndiURL:
 
 ###########################
 #
+# FileStorage Configuration
+#
+
+# Storage location of FileStorage in case of file system
+#exo.files.storage.dir=${exo.data.dir}/files
+
+# Storage provider configuration :
+#fs (default value) :  file system
+#rdbms : binary stored in DB
+#exo.files.binaries.storage.type=fs
+
+#Retention time before cleanup removed files
+#exo.commons.FileStorageCleanJob.retention-time
+
+#Enable FileStorageClean Job
+#exo.commons.FileStorageCleanJob.enabled=true
+
+#Job expression for cleanup removed files
+#exo.commons.FileStorageCleanJob.expression=0 0 11 ? * SUN
+
+# Algoithm for generating hash (checksum) for files stored in RDBMS
+#exo.file-rdbms.algorithm.checksum=MD5
+
+###########################
+#
 # Misc
 #
 

--- a/extension/config/src/main/resources/conf/platform/configuration.properties
+++ b/extension/config/src/main/resources/conf/platform/configuration.properties
@@ -869,6 +869,9 @@ gatein.portal.idm.destroyuserportal=${exo.portal.idm.destroyuserportal:true}
 
 exo.uploadLimit=${exo.uploadLimit:200}
 
+# Algoithm for generating hash (checksum) for files stored in RDBMS
+exo.file-rdbms.algorithm.checksum=${exo.file-rdbms.algorithm.checksum:MD5}
+
 
 ###########################
 #

--- a/extension/config/src/main/resources/conf/platform/exo-sample.properties
+++ b/extension/config/src/main/resources/conf/platform/exo-sample.properties
@@ -487,6 +487,9 @@
 #Job expression for cleanup removed files
 #exo.commons.FileStorageCleanJob.expression=0 0 11 ? * SUN
 
+# Algoithm for generating hash (checksum) for files stored in RDBMS
+#exo.file-rdbms.algorithm.checksum=MD5
+
 ###########################
 #
 # Caches Configuration


### PR DESCRIPTION
The checksum algorithm used to generate hash for files could be configured using the property *exo.file-rdbms.algorithm.checksum* . We added this property to configuration.properties and exo-sample.properties to simplify overriding it if needed.